### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "0.2.0"

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	Version     = "0.1.0"
+	Version     = "0.2.0"
 	articleLink = "https://jtprog.ru/interview-task-0003/"
 )
 


### PR DESCRIPTION
Подготовка релиза **0.2.0**: бамп `Version` в коде и `version`/`appVersion` в Helm-чарте.

Релиз включает изменения из #4:
- фикс DoS в `cubeRoot` (отклонение `NaN`/`Inf`, iteration cap)
- hardening HTTP (тайм-ауты, whitelist `GET`)
- изоляция `/metrics` на отдельный internal-порт (**ломающее** для скрейперов `:8080/metrics`)
- Helm NetworkPolicy, Grafana auth, CI с govulncheck/gosec, обновление зависимостей