### PR TITLE
fix: устранение UndefinedVar warning в Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,10 @@ RUN chmod +x /docker-entrypoint.sh
 COPY --from=builder /go/bin/cubic-root /cubic-root
 
 # Устанавливаем переменные окружения
-ENV PORT=$PORT
-ENV DEBUG=$DEBUG
+ARG http_port=8080
+ARG debug_mode=false
+ENV PORT=$http_port
+ENV DEBUG=$debug_mode
 
 EXPOSE 8080 9090
 


### PR DESCRIPTION
В финальном стейдже `Dockerfile` строки `ENV PORT=$PORT` / `ENV DEBUG=$DEBUG` ссылались на переменные, не определённые в этом стейдже (`ARG` из стейджа `builder` не наследуются через новый `FROM`). BuildKit выдавал warning `UndefinedVar` и фактически присваивал пустые значения.

Объявляем `ARG http_port=8080` / `ARG debug_mode=false` в финальном стейдже и берём `ENV` из них. Поведение по умолчанию не меняется (приложение и так дефолтит `PORT=8080`), warning'и уходят.

Замечено в логе сборки Docker-образа при публикации релиза 0.2.0.